### PR TITLE
Add PostgreSQL persistence with Flyway

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Esta aplicación contiene un ejemplo mínimo de cómo exponer eventos utilizando
 ## Requisitos
 - Java 11
 - Maven
+- PostgreSQL
+
+La base de datos se inicializa y versiona autom\u00e1ticamente con Flyway al arrancar la aplicaci\u00f3n.
+Antes de ejecutar la aplicacion crea una base de datos llamada `icalendar` y un usuario `icaluser` con contrasena `icalpass`.
 
 ## Ejecución
 ```
@@ -12,6 +16,6 @@ mvn spring-boot:run
 ```
 
 Los endpoints principales son:
-- `GET /events` lista los eventos almacenados en memoria.
+- `GET /events` lista los eventos guardados en la base de datos.
 - `POST /events` crea un nuevo evento.
 - `GET /events/{id}/ical` descarga el evento en formato `.ics`.

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,19 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/example/icalendar/controller/CalendarController.java
+++ b/src/main/java/com/example/icalendar/controller/CalendarController.java
@@ -37,8 +37,8 @@ public class CalendarController {
     public ResponseEntity<CalendarEvent> create(
             @RequestParam String summary,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end) {
-        CalendarEvent event = service.addEvent(new CalendarEvent(null, summary, start, end));
+            @RequestParam("end") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endTime) {
+        CalendarEvent event = service.addEvent(new CalendarEvent(null, summary, start, endTime));
         return ResponseEntity.created(URI.create("/events/" + event.getId())).body(event);
     }
 
@@ -52,7 +52,7 @@ public class CalendarController {
         VEvent vEvent = new VEvent();
         vEvent.getProperties().add(new Summary(event.getSummary()));
         vEvent.getProperties().add(new DtStart(event.getStart()));
-        vEvent.getProperties().add(new DtEnd(event.getEnd()));
+        vEvent.getProperties().add(new DtEnd(event.getEndTime()));
 
         Calendar calendar = new Calendar();
         calendar.getComponents().add(vEvent);

--- a/src/main/java/com/example/icalendar/model/CalendarEvent.java
+++ b/src/main/java/com/example/icalendar/model/CalendarEvent.java
@@ -1,20 +1,29 @@
 package com.example.icalendar.model;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Column;
 import java.time.LocalDateTime;
 
+@Entity
 public class CalendarEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String summary;
     private LocalDateTime start;
-    private LocalDateTime end;
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
 
     public CalendarEvent() {}
 
-    public CalendarEvent(Long id, String summary, LocalDateTime start, LocalDateTime end) {
+    public CalendarEvent(Long id, String summary, LocalDateTime start, LocalDateTime endTime) {
         this.id = id;
         this.summary = summary;
         this.start = start;
-        this.end = end;
+        this.endTime = endTime;
     }
 
     public Long getId() {
@@ -41,11 +50,11 @@ public class CalendarEvent {
         this.start = start;
     }
 
-    public LocalDateTime getEnd() {
-        return end;
+    public LocalDateTime getEndTime() {
+        return endTime;
     }
 
-    public void setEnd(LocalDateTime end) {
-        this.end = end;
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
     }
 }

--- a/src/main/java/com/example/icalendar/repository/CalendarEventRepository.java
+++ b/src/main/java/com/example/icalendar/repository/CalendarEventRepository.java
@@ -1,0 +1,7 @@
+package com.example.icalendar.repository;
+
+import com.example.icalendar.model.CalendarEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Long> {
+}

--- a/src/main/java/com/example/icalendar/service/CalendarService.java
+++ b/src/main/java/com/example/icalendar/service/CalendarService.java
@@ -1,29 +1,28 @@
 package com.example.icalendar.service;
 
 import com.example.icalendar.model.CalendarEvent;
+import com.example.icalendar.repository.CalendarEventRepository;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 @Service
 public class CalendarService {
-    private final List<CalendarEvent> events = new ArrayList<>();
-    private final AtomicLong idGenerator = new AtomicLong(1);
+    private final CalendarEventRepository repository;
+
+    public CalendarService(CalendarEventRepository repository) {
+        this.repository = repository;
+    }
 
     public List<CalendarEvent> getEvents() {
-        return Collections.unmodifiableList(events);
+        return repository.findAll();
     }
 
     public CalendarEvent addEvent(CalendarEvent event) {
-        event.setId(idGenerator.getAndIncrement());
-        events.add(event);
-        return event;
+        return repository.save(event);
     }
 
     public CalendarEvent getEvent(Long id) {
-        return events.stream().filter(e -> e.getId().equals(id)).findFirst().orElse(null);
+        return repository.findById(id).orElse(null);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:postgresql://localhost:5432/icalendar
+spring.datasource.username=icaluser
+spring.datasource.password=icalpass
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.show-sql=true

--- a/src/main/resources/db/migration/V1__create_events_table.sql
+++ b/src/main/resources/db/migration/V1__create_events_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE calendar_event (
+    id SERIAL PRIMARY KEY,
+    summary VARCHAR(255) NOT NULL,
+    start TIMESTAMP NOT NULL,
+    end_time TIMESTAMP NOT NULL
+);


### PR DESCRIPTION
## Summary
- store events using Spring Data JPA instead of in-memory collection
- integrate PostgreSQL and Flyway migrations
- map `CalendarEvent` as a JPA entity
- adjust controller to use new model
- document DB setup in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686bf9e7fdc4832c886426b1073536b6