### PR TITLE
Add Swagger and Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3.8.5-openjdk-11 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn package -DskipTests
+
+FROM openjdk:11-jre-slim
+WORKDIR /app
+COPY --from=build /app/target/icalendar-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,20 @@ Los endpoints principales son:
 - `GET /events` lista los eventos guardados en la base de datos.
 - `POST /events` crea un nuevo evento.
 - `GET /events/{id}/ical` descarga el evento en formato `.ics`.
+
+## Documentación Swagger
+
+Al arrancar la aplicación se genera automáticamente la documentación OpenAPI.
+Puedes consultarla en `http://localhost:8080/swagger-ui.html`.
+
+## Uso con Docker Compose
+
+Se incluye un archivo `docker-compose.yml` que levanta la aplicación junto con
+una base de datos PostgreSQL.
+
+```bash
+docker compose up --build
+```
+
+Esto compilará la aplicación y la expondrá en `http://localhost:8080` mientras
+que la base de datos estará disponible en el contenedor `db`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:14
+    environment:
+      POSTGRES_DB: icalendar
+      POSTGRES_USER: icaluser
+      POSTGRES_PASSWORD: icalpass
+    ports:
+      - "5432:5432"
+  app:
+    build: .
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/icalendar
+      SPRING_DATASOURCE_USERNAME: icaluser
+      SPRING_DATASOURCE_PASSWORD: icalpass

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>ical4j</artifactId>
             <version>3.0.27</version>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.6.15</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary
- document Swagger UI endpoint and Docker compose usage
- add Swagger (springdoc-openapi) dependency
- provide Dockerfile for building the Spring Boot app
- add docker-compose.yml to run app with Postgres

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686bfbd94e04832c8f8fc6957eb8250f