### PR TITLE
Fix migration schema and update Postgres port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: icaluser
       POSTGRES_PASSWORD: icalpass
     ports:
-      - "5432:5432"
+      - "5433:5432"
   app:
     build: .
     depends_on:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/icalendar
+spring.datasource.url=jdbc:postgresql://localhost:5433/icalendar
 spring.datasource.username=icaluser
 spring.datasource.password=icalpass
 spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/db/migration/V1__create_events_table.sql
+++ b/src/main/resources/db/migration/V1__create_events_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE calendar_event (
-    id SERIAL PRIMARY KEY,
+    id BIGSERIAL PRIMARY KEY,
     summary VARCHAR(255) NOT NULL,
     start TIMESTAMP NOT NULL,
     end_time TIMESTAMP NOT NULL


### PR DESCRIPTION
## Summary
- expose PostgreSQL as port 5433
- update local datasource configuration
- use `BIGSERIAL` for primary key in migration

## Testing
- `mvn test` *(fails: could not download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686c03cfc950832ca2c7679abc306b36